### PR TITLE
Regex for Metric

### DIFF
--- a/ospfcli2dot
+++ b/ospfcli2dot
@@ -177,7 +177,7 @@ with open(filename, 'r') as infile:
 		if(m):
 			transit = m.group(1)
 			continue
-		m = re.search('TOS 0 Metrics: (\d*)', line)
+		m = re.search('\s+TOS\s+\d\s+Metric(s)?:\s+(\d*)', line)
 		if(m):
 			if(neighbour is not None):
 				rtr.addlink(neighbour, interfaceip, m.group(1))


### PR DESCRIPTION
Script doesn't work well with Nexus output where we don't have "Metrics", but "Metric" after TOS type field. Regex doesn't match and as a result diagram is generated without connections. Setting "s" character in regex as optional will make the script also working with Nexus output.
