### PR TITLE
Fix undefined area set if grouping is not used.

### DIFF
--- a/ospfcli2dot
+++ b/ospfcli2dot
@@ -212,12 +212,12 @@ if(len(filename) > 0):
 						r.sethostname(splitline[1])
 
 
+areas = set()
 separator = input ("If you want to group by hostname, enter the separator now\n (or press enter to continue): ")
 if(len(separator) > 0):
 	firstlast = ''
 	while((firstlast != 'f') & (firstlast != 'l')):
 		firstlast = input("Do you want to group by the [f]irst or [l]ast part of the hostname? ")
-	areas = set()
 	if(firstlast == 'f'):
 		firstlast = 0
 	else:


### PR DESCRIPTION
This fixes the following error if host grouping is not used:

```
./ospfcli2dot 
ospfcli2dot - takes the output of "show ip ospf database router" and optionally a hostfile
outputs a GraphViz DOT file corresponding to the network topology

v0.3 alpha, By Foeh Mannay, December 2017

Enter input filename: ospf.show
Enter hostnames file or press enter to continue without one: 
If you want to group by hostname, enter the separator now
 (or press enter to continue): 
Enter output filename: ospf.dot
Traceback (most recent call last):
  File "./ospfcli2dot", line 233, in <module>
    if(areas):
NameError: name 'areas' is not defined
```