### PR TITLE
Sanitize cluster names (i.e. they must not contain hyphens).

### DIFF
--- a/ospfcli2dot
+++ b/ospfcli2dot
@@ -232,7 +232,7 @@ with open(filename, 'w') as outfile:
 	# If we have areas defined, create them and put the routers inside:
 	if(areas):
 		for a in areas:
-			outfile.write("subgraph cluster_" + a + " {\n\tlabel=\"" + a + "\"\n")
+			outfile.write("subgraph cluster_" + re.sub(r"[^a-zA-Z_]", "_", a) + " {\n\tlabel=\"" + a + "\"\n")
 			for r in routers:
 				if(r.hostname.split(separator)[firstlast] == a):
 					outfile.write(r.dottifyrouter())


### PR DESCRIPTION
If the location contains special characters (i.e. hyphens) graphviz does complain about invalid syntax.